### PR TITLE
[Feature] Optional react-router installation, + 1 misc fix

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -68,6 +68,10 @@ module.exports = yeoman.Base.extend({
                 name: 'authorEmail',
                 message: formatPrompt(chalk.bold.white('What is your email?')),
                 default: this.user.git.email()
+            }, {
+                type: 'confirm',
+                name: 'include_routing',
+                message: formatPrompt(chalk.bold.white('Would you like routing to be set up? (via react-router)')),
             }];
 
             this.prompt(prompts, function(answers) {
@@ -100,7 +104,6 @@ module.exports = yeoman.Base.extend({
             'src/example/index.js',
             'src/example/style.styl',
             'src/example/__tests__/index.js',
-            'src/index.js',
             'src/style.styl',
         ]);
 
@@ -108,6 +111,7 @@ module.exports = yeoman.Base.extend({
             'CHANGELOG.md',
             'package.json',
             'README.md',
+            'src/index.js',
             'src/static/index.html'
         ], this.answers);
     },

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "react": "^15.0.0",
+    <% if (include_routing) { %>"react-router": "^2.0.0",<% } %>
     "react-dom": "^15.0.0"
   },
   "devDependencies": {

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,11 +1,53 @@
 import React from 'react';
 import {render} from 'react-dom';
+
+<% if (include_routing) { %>import {
+    Router,
+    Route,
+    IndexRoute,
+    browserHistory,
+} from 'react-router';<% } %>
+
 import Example from './example';
 
-// Do bootstrapping here... perhaps add something like react-router?
+<% if (include_routing) { %>class Application extends React.Component {
+    render() {
+        return (
+            <main>
+                {React.cloneElement(
+                    this.props.children,
+                    this.props.children.props.route,
+                )}
+            </main>
+        );
+    }
+}
 
-render(
+class NotFound extends React.Component {
+    render() {
+        return (
+            <main>404</main>
+        );
+    }
+}
+
+const app = (
+    <Router history={browserHistory}>
+        <Route path='/' component={Application}>
+            <IndexRoute
+                component={Example}
+                title='Hello World!'
+                description='This is your first React component...' />
+
+            <Route path='*' component={NotFound} />
+        </Route>
+    </Router>
+);<% } else { %>const app = (
     <Example
         title='Hello World!'
-        description='This is your first React component...' />, document.querySelector('main')
-);
+        description='This is your first React component...' />
+);<% } %>
+
+// Do bootstrapping here...
+
+render(app, document.getElementById('__root'));

--- a/generators/app/templates/src/static/index.html
+++ b/generators/app/templates/src/static/index.html
@@ -2,12 +2,12 @@
 <html>
     <head>
         <title><%= appName %></title>
-        <link href="./assets/style.css" rel="stylesheet" />
+        <link href="/assets/style.css" rel="stylesheet" />
     </head>
     <body>
-        <main></main>
+        <div id="__root"></div>
 
         <!-- a sourcemap is included back to the original files -->
-        <script src="./assets/bundle.js"></script>
+        <script src="/assets/bundle.js"></script>
     </body>
 </html>


### PR DESCRIPTION
There is now an additional prompt during `yo enigma` on whether you want to automatically have react-router set up. It will default to HTML5 pushstate-based routing, which budo (the livereload server) is configured to support.
- Fixed `static/index.html` using relative paths when they should always be absolute to the serving root when using pushstate-based routing, since path nesting is an illusion.
- No longer using `<main>` as the React root, as semantically it may make more sense to be used deeper in the nested tree adjacent to a `<header>` or something similar.
